### PR TITLE
Update Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven
+FROM maven:3.6.1-jdk-8-alpine AS MAVEN_BUILD
 
 WORKDIR /opt/stedi
 
@@ -6,7 +6,10 @@ COPY . ./
 
 RUN mvn clean package
 
-ENTRYPOINT ["java","-jar","/opt/stedi/target/StepTimerWebsocket-1.0-SNAPSHOT.jar"]
+FROM openjdk:8-jre-alpine3.9
+
+COPY --from=MAVEN_BUILD /opt/stedi/target/StepTimerWebsocket-1.0-SNAPSHOT.jar /stedi.jar
+
+ENTRYPOINT ["java", "-jar", "/stedi.jar"]
 
 EXPOSE 4567
-


### PR DESCRIPTION
I have implemented a multi-stage build, as per https://codefresh.io/docker-tutorial/create-docker-images-for-java/

The "FROM openjdk:8-jre-alpine3.9" on line 9 will discard the unneeded parts of the maven build. The alpine versions of maven and java are chosen because they are the smallest. This change reduced my image size from about 750 MB to only 120 MB. Build time was also reduced from about 100 seconds to only 42 seconds.

A possible downside to this change is that the latest versions of java and maven are not being used.